### PR TITLE
Implement API endpoint for rate lookup

### DIFF
--- a/bph_lookup/core/serializers.py
+++ b/bph_lookup/core/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from .models import FeeScheduleRate
+
+class FeeScheduleRateSerializer(serializers.ModelSerializer):
+    procedure_code = serializers.CharField(source='procedure_code.procedure_code')
+    description = serializers.CharField(source='procedure_code.description')
+    region = serializers.CharField(source='region.region_name', allow_null=True)
+    state = serializers.CharField(source='fee_schedule.state.state_code')
+    schedule_type = serializers.CharField(source='fee_schedule.schedule_type')
+
+    class Meta:
+        model = FeeScheduleRate
+        fields = [
+            'id', 'state', 'schedule_type', 'procedure_code', 'description',
+            'modifier', 'region', 'rate', 'rate_unit'
+        ]

--- a/bph_lookup/core/tests.py
+++ b/bph_lookup/core/tests.py
@@ -1,0 +1,45 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from .models import State, Region, ProcedureCode, FeeSchedule, FeeScheduleRate
+
+class RateLookupAPITest(APITestCase):
+    def setUp(self):
+        self.state = State.objects.create(
+            state_code="CA", state_name="California",
+            effective_date="2020-01-01"
+        )
+        self.region = Region.objects.create(
+            state=self.state,
+            region_type="Carrier",
+            region_code="001",
+            region_name="CA Region"
+        )
+        self.code = ProcedureCode.objects.create(
+            procedure_code="99213",
+            description="Office visit",
+            code_type="CPT"
+        )
+        schedule = FeeSchedule.objects.create(
+            state=self.state,
+            schedule_type="Physician",
+            effective_date="2020-01-01"
+        )
+        self.rate = FeeScheduleRate.objects.create(
+            fee_schedule=schedule,
+            procedure_code=self.code,
+            modifier="",
+            region=self.region,
+            rate=100.00,
+            rate_unit="1",
+            effective_date="2020-01-01"
+        )
+
+    def test_rate_lookup_api(self):
+        url = reverse('rate_lookup_api')
+        response = self.client.get(url, {
+            'state': 'CA',
+            'procedure_code': '99213'
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['procedure_code'], '99213')

--- a/bph_lookup/core/urls.py
+++ b/bph_lookup/core/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.rate_lookup, name='rate_lookup'),
-] 
+    path('api/rates/', views.rate_lookup_api, name='rate_lookup_api'),
+]

--- a/bph_lookup/core/views.py
+++ b/bph_lookup/core/views.py
@@ -1,5 +1,9 @@
 from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
 from .models import State, ProcedureCode, FeeScheduleRate, Region
+from .serializers import FeeScheduleRateSerializer
 
 def rate_lookup(request):
     """
@@ -24,4 +28,29 @@ def rate_lookup(request):
         ).select_related('fee_schedule', 'region', 'procedure_code')
         context['rates'] = rates
 
-    return render(request, "core/rate_lookup.html", context) 
+    return render(request, "core/rate_lookup.html", context)
+
+
+@api_view(["GET"])
+def rate_lookup_api(request):
+    """Return fee schedule rates matching query parameters."""
+    state_code = request.query_params.get("state")
+    procedure_code = request.query_params.get("procedure_code")
+    zip_code = request.query_params.get("zip_code")
+
+    region = None
+    if state_code:
+        region = Region.objects.filter(state__state_code=state_code).first()
+
+    rates = FeeScheduleRate.objects.all()
+    if state_code:
+        rates = rates.filter(fee_schedule__state__state_code=state_code)
+    if procedure_code:
+        rates = rates.filter(procedure_code__procedure_code=procedure_code)
+    if region:
+        rates = rates.filter(region=region)
+
+    serializer = FeeScheduleRateSerializer(
+        rates.select_related("procedure_code", "fee_schedule", "region"), many=True
+    )
+    return Response(serializer.data)


### PR DESCRIPTION
## Summary
- add `FeeScheduleRateSerializer` for serializing rates
- expose `/api/rates/` endpoint
- add tests covering the new endpoint

## Testing
- `pip install -r bph_lookup/requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.0)*
- `python bph_lookup/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68479ff7f0a88321883bbee274e01a2e